### PR TITLE
ci: migrate LizardByte/setup-python-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           value=`grep -oP 'dolibarr \K[\d\.]*' conf/dependencies.yml`
           echo "VERSION=$value" >> $GITHUB_ENV
       - name: Setup Python
-        uses: LizardByte/setup-python-action@master
+        uses: LizardByte/actions/actions/setup_python@master
         with:
           python-version: '2.7'
       - name: Build


### PR DESCRIPTION
LizardByte/setup-python-action is deprecated and has moved to LizardByte/actions.